### PR TITLE
Add SSH to installed apps in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN \
   apk update && \
   apk upgrade && \
-  apk add --no-cache git
+  apk add --no-cache openssh-client git
 RUN \
   yarn global add @angular/cli firebase-tools


### PR DESCRIPTION
Git push now fails on `cannot run ssh: No such file or directory`